### PR TITLE
Removing isValidHostname check in flavor of #55

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -38,14 +38,6 @@ describe("sslChecker", () => {
     }
   });
 
-  it("Should return 'Invalid host' when no host provided", async () => {
-    try {
-      await sslChecker();
-    } catch (e) {
-      expect(e).toEqual(new Error("Invalid host"));
-    }
-  });
-
   it("Should return 'Invalid port' when no port provided", async () => {
     try {
       await sslChecker(validSslHost, { port: "port" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,15 +33,6 @@ const sslChecker = (
   }
 ): Promise<IResolvedValues> =>
   new Promise((resolve, reject) => {
-    const isValidHostName =
-      host &&
-      /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/.test(
-        host
-      );
-
-    if (!isValidHostName) {
-      reject(new Error("Invalid host"));
-    }
 
     if (!checkPort(options.port)) {
       reject(Error("Invalid port"));


### PR DESCRIPTION
The check does not work properly and node has excellent error handling itself.