### PR TITLE
Add hostnames of the certificate to response

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ sslChecker("dyaa.me", { method: "GET", port: 443 }).then(console.info);
   "daysRemaining": 90,
   "valid": true,
   "validFrom": "issue date",
-  "validTo": "expiry date"
+  "validTo": "expiry date",
+  "validFor": ["www.example.com", "example.com"]
 }
 ```
 

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -4,6 +4,8 @@ const validSslHost = "badssl.com";
 const expiredSSlHost = "expired.badssl.com";
 const wrongHostDomain = "wrong.host.badssl.com";
 
+const validDomainsForValidSslHost = ["*.badssl.com", "badssl.com"];
+
 describe("sslChecker", () => {
   it("Should return valid values when valid host is passed", async () => {
     const sslDetails = await sslChecker(validSslHost);
@@ -13,7 +15,8 @@ describe("sslChecker", () => {
         daysRemaining: expect.any(Number),
         valid: true,
         validFrom: expect.any(String),
-        validTo: expect.any(String)
+        validTo: expect.any(String),
+        validFor: expect.arrayContaining(validDomainsForValidSslHost),
       })
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,9 @@ const sslChecker = (
 
           const validTo = new Date(valid_to);
 
-          const validFor = subjectaltname.replace(/DNS:/g, "").split(", ");
+          const validFor = subjectaltname
+            .replace(/DNS:|IP Address:/g, "")
+            .split(", ");
 
           resolve({
             daysRemaining: getDaysRemaining(new Date(), validTo),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ interface IResolvedValues {
   validFrom: string;
   validTo: string;
   daysRemaining: number;
+  validFor: string[];
 }
 
 const checkPort = (port: unknown): boolean =>
@@ -54,9 +55,12 @@ const sslChecker = (
           const {
             valid_from,
             valid_to,
+            subjectaltname,
           } = (res.connection as tls.TLSSocket).getPeerCertificate();
 
           const validTo = new Date(valid_to);
+
+          const validFor = subjectaltname.replace(/DNS:/g, "").split(", ");
 
           resolve({
             daysRemaining: getDaysRemaining(new Date(), validTo),
@@ -65,6 +69,7 @@ const sslChecker = (
                 .authorized as boolean) || false,
             validFrom: new Date(valid_from).toISOString(),
             validTo: validTo.toISOString(),
+            validFor,
           });
         }
       );


### PR DESCRIPTION
Adds an array of all hostnames that are covered by the certificate. Uses `subjectaltname` from the `tls` module. 

```js
  console.log(await sslChecker("example.com"));
```

returns:

```json
{
  "daysRemaining": 75,
  "valid": true,
  "validFrom": "2018-11-28T00:00:00.000Z",
  "validTo": "2020-12-02T12:00:00.000Z",
  "validFor": [
    "www.example.org",
    "example.com",
    "example.edu",
    "example.net",
    "example.org",
    "www.example.com",
    "www.example.edu",
    "www.example.net"
  ]
}
```

**Update**: Added clean output for IP addresses:

```js
console.log(await sslChecker("1.1.1.1"));
``` 

returns:

```json
{
  "daysRemaining": 136,
  "valid": true,
  "validFrom": "2019-01-28T00:00:00.000Z",
  "validTo": "2021-02-01T12:00:00.000Z",
  "validFor": [
    "cloudflare-dns.com",
    "*.cloudflare-dns.com",
    "one.one.one.one",
    "1.1.1.1",
    "1.0.0.1",
    "162.159.132.53",
    "2606:4700:4700:0:0:0:0:1111",
    "2606:4700:4700:0:0:0:0:1001",
    "2606:4700:4700:0:0:0:0:64",
    "2606:4700:4700:0:0:0:0:6400",
    "162.159.36.1",
    "162.159.46.1"
  ]
}
```
