### PR TITLE
Fix subsequent calls to sslChecker, fixes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ const getSslDetails = async (hostname: string) =>
 
 ## Options
 
-| Option | Default |                                                    |
-| ------ | ------- | -------------------------------------------------- |
-| method | HEAD    | can be GET too                                     |
-| port   | 443     | Your ssl entrypoint                                |
-| agent  |         | I dont know why but if you'd like provide agent id |
+All valid `https.RequestOptions` values.
+
+| Option             | Default | Description                                        |
+| ------------------ | ------- | -------------------------------------------------- |
+| method             | HEAD    | Can be GET too                                     |
+| port               | 443     | Your SSL/TLS entry point                           |
+| agent              | default | Default HTTPS agent with { maxCachedSessions: 0 }  |
+| rejectUnauthorized | false   | Skips authorization by default                     |
 
 ```ts
 sslChecker("dyaa.me", { method: "GET", port: 443 }).then(console.info);

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -21,6 +21,18 @@ describe("sslChecker", () => {
     );
   });
 
+  it("Should work on subsequent calls for the same domain", async () => {
+    await sslChecker(validSslHost);
+    await new Promise((r) => setTimeout(r, 1000));
+    const sslDetails = await sslChecker(validSslHost);
+
+    expect(sslDetails).toEqual(
+      expect.objectContaining({
+        valid: true,
+      })
+    );
+  });
+
   it("Should return valid = false when provided an expired domain", async () => {
     const sslDetails = await sslChecker(expiredSSlHost);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,19 +24,25 @@ const getDaysRemaining = (validFrom: Date, validTo: Date): number => {
   return daysRemaining;
 };
 
+const DEFAULT_OPTIONS: Partial<https.RequestOptions> = {
+  agent: new https.Agent({
+    maxCachedSessions: 0
+  }),
+  method: "HEAD",
+  port: 443,
+  rejectUnauthorized: false,
+};
+
 const sslChecker = (
   host: string,
-  options: Partial<https.RequestOptions> = {
-    agent: false,
-    method: "HEAD",
-    port: 443,
-    rejectUnauthorized: false,
-  }
+  options: Partial<https.RequestOptions> = {}
 ): Promise<IResolvedValues> =>
   new Promise((resolve, reject) => {
+    options = Object.assign({}, DEFAULT_OPTIONS, options);
 
     if (!checkPort(options.port)) {
       reject(Error("Invalid port"));
+      return;
     }
 
     try {


### PR DESCRIPTION
Hello!

I also encountered a problem guys were discussing in #24. This PR should fix it. Also it fixes incorrect exit logic on "Invalid port".

For reference: https://github.com/nodejs/node/issues/3940. Since this package's only business is checking SSL/TLS certificates, it deserves a default agent with no cache.

P.S. Not reproducible on Windows, hence not that easy to spot.