### PR TITLE
Fix file descriptor leak

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,8 +3,7 @@ import * as fs from 'fs';
 
 import sslChecker from "./";
 
-const wordpressHost = "developer.wordpress.org";
-
+const githubHost = "github.com";
 const validSslHost = "badssl.com";
 const expiredSSlHost = "expired.badssl.com";
 const wrongHostDomain = "wrong.host.badssl.com";
@@ -70,7 +69,7 @@ describe("sslChecker", () => {
     if (process.platform !== 'linux') return
     await new Promise((r) => setTimeout(r, 2000));
     const openFdsBefore = fs.readdirSync('/proc/self/fd').length - 1;
-    await sslChecker(wordpressHost, { method: "HEAD", port: 443 })
+    await sslChecker(githubHost, { method: "HEAD", port: 443 })
     await new Promise((r) => setTimeout(r, 1000));
     const openFdsAfter = fs.readdirSync('/proc/self/fd').length - 1;
     expect(openFdsBefore).toEqual(openFdsAfter);
@@ -80,7 +79,7 @@ describe("sslChecker", () => {
     if (process.platform !== 'linux') return
     await new Promise((r) => setTimeout(r, 2000));
     const openFdsBefore = fs.readdirSync('/proc/self/fd').length - 1;
-    await sslChecker(wordpressHost, { method: "GET", port: 443 })
+    await sslChecker(githubHost, { method: "GET", port: 443 })
     await new Promise((r) => setTimeout(r, 1000));
     const openFdsAfter = fs.readdirSync('/proc/self/fd').length - 1;
     expect(openFdsBefore).toEqual(openFdsAfter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ const sslChecker = (
           const { valid_from, valid_to, subjectaltname } = (
             res.socket as TLSSocket
           ).getPeerCertificate();
+          res.socket.destroy();
 
           if (!valid_from || !valid_to || !subjectaltname) {
             reject(new Error("No certificate"));


### PR DESCRIPTION
In certain cases, sslChecker will hold on to open sockets forever and never close them.

From my experimenting, this seems to happen only with GET requests (rather than the default HEAD), and with sites that send back at least a certain number of bytes with the get request.

The test here shows a get to github.com causing the leak. 

Thanks to https://github.com/siimon/prom-client for the [inspiration](https://github.com/siimon/prom-client/blob/master/lib/metrics/processOpenFileDescriptors.js#L25) in counting open file descriptors.