### PR TITLE
feature: remove subjectaltname check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All valid `https.RequestOptions` values.
 | validateSubjectAltName | false   | Skips returning/validating `subjectaltname`       |
 
 ```ts
-sslChecker("dyaa.me", true, { method: "GET", port: 443 }).then(console.info);
+sslChecker("dyaa.me", { method: "GET", port: 443 }).then(console.info);
 ```
 
 ## Response Example

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All valid `https.RequestOptions` values.
 | validateSubjectAltName | false   | Skips returning/validating `subjectaltname`       |
 
 ```ts
-sslChecker("dyaa.me", { method: "GET", port: 443 }).then(console.info);
+sslChecker("dyaa.me", { method: "GET", port: 443, validateSubjectAltName: true }).then(console.info);
 ```
 
 ## Response Example

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ $ yarn add ssl-checker
 ```ts
 import sslChecker from "ssl-checker";
 
-const getSslDetails = async (hostname: string) =>
-  await sslChecker(hostname`ex. badssl.com`);
+const getSslDetails = async (hostname: string, validateSubjectAltName: boolean) =>
+  await sslChecker(hostname`ex. badssl.com`, validateSubjectAltName`true`);
 ```
 
 ## Options
+
+* `validateSubjectAltName` - If true, requires `subjectaltname` (an optional certificate field) to exist in certificate during validity check.
 
 All valid `https.RequestOptions` values.
 
@@ -37,7 +39,7 @@ All valid `https.RequestOptions` values.
 | rejectUnauthorized | false   | Skips authorization by default                    |
 
 ```ts
-sslChecker("dyaa.me", { method: "GET", port: 443 }).then(console.info);
+sslChecker("dyaa.me", true, { method: "GET", port: 443 }).then(console.info);
 ```
 
 ## Response Example

--- a/README.md
+++ b/README.md
@@ -21,22 +21,21 @@ $ yarn add ssl-checker
 ```ts
 import sslChecker from "ssl-checker";
 
-const getSslDetails = async (hostname: string, validateSubjectAltName: boolean) =>
-  await sslChecker(hostname`ex. badssl.com`, validateSubjectAltName`true`);
+const getSslDetails = async (hostname: string) =>
+  await sslChecker(hostname`ex. badssl.com`);
 ```
 
 ## Options
 
-* `validateSubjectAltName` - If true, requires `subjectaltname` (an optional certificate field) to exist in certificate during validity check.
-
 All valid `https.RequestOptions` values.
 
-| Option             | Default | Description                                       |
-| ------------------ | ------- | ------------------------------------------------- |
-| method             | HEAD    | Can be GET too                                    |
-| port               | 443     | Your SSL/TLS entry point                          |
-| agent              | default | Default HTTPS agent with { maxCachedSessions: 0 } |
-| rejectUnauthorized | false   | Skips authorization by default                    |
+| Option                 | Default | Description                                       |
+| ------------------     | ------- | ------------------------------------------------- |
+| method                 | HEAD    | Can be GET too                                    |
+| port                   | 443     | Your SSL/TLS entry point                          |
+| agent                  | default | Default HTTPS agent with { maxCachedSessions: 0 } |
+| rejectUnauthorized     | false   | Skips authorization by default                    |
+| validateSubjectAltName | false   | Skips returning/validating `subjectaltname`       |
 
 ```ts
 sslChecker("dyaa.me", true, { method: "GET", port: 443 }).then(console.info);
@@ -53,6 +52,8 @@ sslChecker("dyaa.me", true, { method: "GET", port: 443 }).then(console.info);
   "validFor": ["www.example.com", "example.com"]
 }
 ```
+
+**NOTE: `validFor` is only returned if `validateSubjectAltName` is set to `true`**
 
 #### License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssl-checker",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ssl-checker",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssl-checker",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "ssl-checker",
   "main": "./lib/cjs/index.js",
   "module": "./lib/es/index.js",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,15 +4,12 @@ import * as fs from 'fs';
 import sslChecker from "./";
 
 const githubHost = "github.com";
-const validSslHost = "badssl.com";
 const expiredSSlHost = "expired.badssl.com";
 const wrongHostDomain = "wrong.host.badssl.com";
 
-const validDomainsForValidSslHost = ["*.badssl.com", "badssl.com"];
-
 describe("sslChecker", () => {
   it("Should return valid values when valid host is passed", async () => {
-    const sslDetails = await sslChecker(validSslHost, {validateSubjectAltName: true});
+    const sslDetails = await sslChecker(githubHost, {validateSubjectAltName: true});
 
     expect(sslDetails).toEqual(
       expect.objectContaining({
@@ -20,15 +17,15 @@ describe("sslChecker", () => {
         valid: true,
         validFrom: expect.any(String),
         validTo: expect.any(String),
-        validFor: expect.arrayContaining(validDomainsForValidSslHost),
+        validFor: expect.arrayContaining(["github.com", "www.github.com"]),
       })
     );
   });
 
   it("Should work on subsequent calls for the same domain", async () => {
-    await sslChecker(validSslHost);
+    await sslChecker(githubHost);
     await new Promise((r) => setTimeout(r, 1000));
-    const sslDetails = await sslChecker(validSslHost);
+    const sslDetails = await sslChecker(githubHost);
 
     expect(sslDetails).toEqual(
       expect.objectContaining({
@@ -48,7 +45,7 @@ describe("sslChecker", () => {
   });
 
   it("Should allow for specifying `subjectaltname` as a non required field for cert validity", async () => {
-    const sslDetails = await sslChecker(validSslHost, {validateSubjectAltName: false});
+    const sslDetails = await sslChecker(githubHost, {validateSubjectAltName: false});
 
     expect(sslDetails).toEqual(
       expect.objectContaining({
@@ -72,7 +69,7 @@ describe("sslChecker", () => {
 
   it("Should return 'Invalid port' when no port provided", async () => {
     try {
-      await sslChecker(validSslHost, { port: "port" });
+      await sslChecker(githubHost, { port: "port" });
     } catch (e) {
       expect(e).toEqual(new Error("Invalid port"));
     }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,7 @@ const validDomainsForValidSslHost = ["*.badssl.com", "badssl.com"];
 
 describe("sslChecker", () => {
   it("Should return valid values when valid host is passed", async () => {
-    const sslDetails = await sslChecker(validSslHost);
+    const sslDetails = await sslChecker(validSslHost, {validateSubjectAltName: true});
 
     expect(sslDetails).toEqual(
       expect.objectContaining({
@@ -43,6 +43,19 @@ describe("sslChecker", () => {
     expect(sslDetails).toEqual(
       expect.objectContaining({
         valid: false,
+      })
+    );
+  });
+
+  it("Should allow for specifying `subjectaltname` as a non required field for cert validity", async () => {
+    const sslDetails = await sslChecker(validSslHost, {validateSubjectAltName: false});
+
+    expect(sslDetails).toEqual(
+      expect.objectContaining({
+        daysRemaining: expect.any(Number),
+        valid: true,
+        validFrom: expect.any(String),
+        validTo: expect.any(String),
       })
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ interface IResolvedValues {
   validFrom: string;
   validTo: string;
   daysRemaining: number;
-  validFor: string[];
+  validFor?: string[];
 }
 
 const checkPort = (port: unknown): boolean =>
@@ -24,7 +24,9 @@ const getDaysRemaining = (validFrom: Date, validTo: Date): number => {
   return daysRemaining;
 };
 
-const DEFAULT_OPTIONS: Partial<https.RequestOptions> = {
+type Options = https.RequestOptions & { validateSubjectAltName?:boolean };
+
+const DEFAULT_OPTIONS: Partial<Options> = {
   agent: new https.Agent({
     maxCachedSessions: 0,
   }),
@@ -36,7 +38,7 @@ const DEFAULT_OPTIONS: Partial<https.RequestOptions> = {
 
 const sslChecker = (
   host: string,
-  options: Partial<https.RequestOptions> = {}
+  options: Partial<Options> = {}
 ): Promise<IResolvedValues> =>
   new Promise((resolve, reject) => {
     options = Object.assign({}, DEFAULT_OPTIONS, options);


### PR DESCRIPTION
Added additional config option to choose if the `subjectaltname` should be required for a given certificate to be valid, since it is an optional field to configure within a certificate. Allows for more flexibility to validate certificates without this configured.